### PR TITLE
Bug/22 Enable MGRS Tile to Control Tile search (MAPCO-4739)

### DIFF
--- a/src/control/tile/DAL/queries.ts
+++ b/src/control/tile/DAL/queries.ts
@@ -1,7 +1,8 @@
 import { estypes } from '@elastic/elasticsearch';
+import { BBox } from 'geojson';
 import { CommonRequestParameters } from '../../../common/interfaces';
 import { ELASTIC_KEYWORDS } from '../../constants';
-import { ConvertSnakeToCamelCase, geoContextQuery } from '../../../common/utils';
+import { ConvertSnakeToCamelCase, geoContextQuery, parseGeo } from '../../../common/utils';
 
 export interface TileQueryParams extends ConvertSnakeToCamelCase<CommonRequestParameters> {
   tile?: string;
@@ -14,7 +15,7 @@ export const queryForTiles = ({
   geoContext,
   geoContextMode,
   disableFuzziness,
-}: Omit<TileQueryParams, 'subTile' | 'limit'> & Required<Pick<TileQueryParams, 'tile'>>): estypes.SearchRequest => ({
+}: Omit<TileQueryParams, 'subTile' | 'limit' | 'mgrs'> & Required<Pick<TileQueryParams, 'tile'>>): estypes.SearchRequest => ({
   query: {
     bool: {
       must: [
@@ -45,7 +46,7 @@ export const queryForSubTiles = ({
   geoContextMode,
   subTile,
   disableFuzziness,
-}: Required<TileQueryParams>): estypes.SearchRequest => ({
+}: Omit<Required<TileQueryParams>, 'mgrs'>): estypes.SearchRequest => ({
   query: {
     bool: {
       must: [
@@ -74,3 +75,39 @@ export const queryForSubTiles = ({
     },
   },
 });
+
+export const queryForTilesByBbox = ({
+  bbox,
+  geoContext,
+  geoContextMode,
+}: { bbox: BBox } & ConvertSnakeToCamelCase<CommonRequestParameters>): estypes.SearchRequest => {
+  const { filter: geoCOntextQueryFilter, should } = geoContextQuery(geoContext, geoContextMode);
+
+  const query: estypes.SearchRequest = {
+    query: {
+      bool: {
+        must: [
+          {
+            term: {
+              ['properties.TYPE.keyword']: 'TILE',
+            },
+          },
+        ],
+        filter: [
+          {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            geo_shape: {
+              [ELASTIC_KEYWORDS.geometry]: {
+                shape: parseGeo({ bbox }),
+                relation: 'intersects',
+              },
+            },
+          },
+          ...(geoCOntextQueryFilter ?? []),
+        ],
+        should: should ?? {},
+      },
+    },
+  };
+  return query;
+};

--- a/src/control/tile/DAL/queries.ts
+++ b/src/control/tile/DAL/queries.ts
@@ -105,7 +105,7 @@ export const queryForTilesByBbox = ({
           },
           ...(geoCOntextQueryFilter ?? []),
         ],
-        should: should ?? {},
+        should,
       },
     },
   };

--- a/src/control/tile/DAL/tileRepository.ts
+++ b/src/control/tile/DAL/tileRepository.ts
@@ -24,6 +24,13 @@ const createTileRepository = (client: ElasticClient, config: IConfig, logger: Lo
 
       return response;
     },
+    async getTilesByBbox(searchParams: { bbox: BBox } & Omit<TileQueryParams, 'tile' | 'subTile' | 'mgrs'>): Promise<estypes.SearchResponse<Tile>> {
+      const response = await queryElastic<Tile>(client, {
+        ...additionalControlSearchProperties(config, searchParams.limit),
+        ...queryForTilesByBbox(searchParams),
+      });
+      return response;
+    },
   };
 };
 

--- a/src/control/tile/DAL/tileRepository.ts
+++ b/src/control/tile/DAL/tileRepository.ts
@@ -1,26 +1,33 @@
 import { Logger } from '@map-colonies/js-logger';
 import { estypes } from '@elastic/elasticsearch';
 import { FactoryFunction } from 'tsyringe';
+import { BBox } from 'geojson';
 import { ElasticClient, ElasticClients } from '../../../common/elastic';
 import { Tile } from '../models/tile';
 import { queryElastic } from '../../../common/elastic/utils';
 import { IConfig } from '../../../common/interfaces';
 import { SERVICES } from '../../../common/constants';
 import { additionalControlSearchProperties } from '../../utils';
-import { queryForTiles, queryForSubTiles, TileQueryParams } from './queries';
+import { queryForTiles, queryForSubTiles, TileQueryParams, queryForTilesByBbox } from './queries';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const createTileRepository = (client: ElasticClient, config: IConfig, logger: Logger) => {
   return {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    async getTiles(tileQueryParams: TileQueryParams & Required<Pick<TileQueryParams, 'tile'>>, size: number): Promise<estypes.SearchResponse<Tile>> {
-      const response = await queryElastic<Tile>(client, { ...additionalControlSearchProperties(config, size), ...queryForTiles(tileQueryParams) });
+    async getTiles(tileQueryParams: TileQueryParams & Required<Pick<TileQueryParams, 'tile'>>): Promise<estypes.SearchResponse<Tile>> {
+      const response = await queryElastic<Tile>(client, {
+        ...additionalControlSearchProperties(config, tileQueryParams.limit),
+        ...queryForTiles(tileQueryParams),
+      });
 
       return response;
     },
 
-    async getSubTiles(tileQueryParams: Required<TileQueryParams>, size: number): Promise<estypes.SearchResponse<Tile>> {
-      const response = await queryElastic<Tile>(client, { ...additionalControlSearchProperties(config, size), ...queryForSubTiles(tileQueryParams) });
+    async getSubTiles(tileQueryParams: Required<TileQueryParams>): Promise<estypes.SearchResponse<Tile>> {
+      const response = await queryElastic<Tile>(client, {
+        ...additionalControlSearchProperties(config, tileQueryParams.limit),
+        ...queryForSubTiles(tileQueryParams),
+      });
 
       return response;
     },

--- a/src/control/tile/models/tileManager.ts
+++ b/src/control/tile/models/tileManager.ts
@@ -21,8 +21,6 @@ export class TileManager {
   ) {}
 
   public async getTiles(tileQueryParams: TileQueryParams): Promise<FeatureCollection<Tile>> {
-    const { limit } = tileQueryParams;
-
     if (
       (tileQueryParams.tile === undefined && tileQueryParams.mgrs === undefined) ||
       (tileQueryParams.tile !== undefined && tileQueryParams.mgrs !== undefined)
@@ -35,8 +33,9 @@ export class TileManager {
     if (tileQueryParams.mgrs !== undefined) {
       elasticResponse = await this.tileRepository.getTilesByBbox({ bbox: mgrs.inverse(tileQueryParams.mgrs), ...tileQueryParams });
     } else if (tileQueryParams.subTile ?? '') {
+      elasticResponse = await this.tileRepository.getSubTiles(tileQueryParams as Required<TileQueryParams>);
     } else {
-      elasticResponse = await this.tileRepository.getTiles(tileQueryParams as TileQueryParams & Required<Pick<TileQueryParams, 'tile'>>, limit);
+      elasticResponse = await this.tileRepository.getTiles(tileQueryParams as TileQueryParams & Required<Pick<TileQueryParams, 'tile'>>);
     }
 
     return formatResponse(elasticResponse, tileQueryParams, this.application.controlObjectDisplayNamePrefixes);


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

Related issues: #22 
Closes #22 

Further  information:
Added the implementation to be able to search for control tiles via MGRS tile. 
It will result back with all of the control tiles that intersects with the MGRS tile.
