### PR TITLE
Fix: malformed openapi

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -85,6 +85,7 @@
     }
   },
   "application": {
+    "site": "local",
     "services": {
       "tokenTypesUrl": "http://NLP_ANALYSES"
     },

--- a/config/test.json
+++ b/config/test.json
@@ -59,6 +59,7 @@
     }
   },
   "application": {
+    "site": "test",
     "services": {
       "tokenTypesUrl": "http://localhost:5001/NLP_ANALYSES"
     },

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -538,9 +538,7 @@ components:
       in: 'query'
       description: 'Choose whether geo_context query parameter will be a filter or a bias value'
       schema:
-        type: string
-        enum: ['filter', 'bias']
-
+        $ref: '#/components/schemas/geo_context_mode'
   schemas:
     errorSchema:
       type: 'object'
@@ -764,7 +762,7 @@ components:
                 geo_context:
                   $ref: '#/components/schemas/geo_context'
                 geo_context_mode:
-                  $ref: '#/components/parameters/geo_context_mode'
+                  $ref: '#/components/schemas/geo_context_mode'
                 disable_fuzziness:
                   $ref: '#/components/schemas/disable_fuzziness'
             response:
@@ -1019,6 +1017,9 @@ components:
               $ref: '#/components/schemas/BoundingBox'
         - $ref: '#/components/schemas/WGS84Circle'
         - $ref: '#/components/schemas/UTMCircle'
+    geo_context_mode:
+      type: string
+      enum: ['filter', 'bias']
     disable_fuzziness:
       type: boolean
       default: false

--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -112,32 +112,32 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - "$ref": "#/components/schemas/genericGeocodingResponse"
-                  - type: "object"
+                  - '$ref': '#/components/schemas/genericGeocodingResponse'
+                  - type: 'object'
                     required:
-                      - "type"
-                      - "features"
+                      - 'type'
+                      - 'features'
                     properties:
                       type:
-                        type: "string"
+                        type: 'string'
                         enum:
-                          - "FeatureCollection"
+                          - 'FeatureCollection'
                       features:
-                        type: "array"
+                        type: 'array'
                         items:
-                          type: "object"
+                          type: 'object'
                           properties:
                             geometry:
                               oneOf:
-                                - $ref: "#/components/schemas/Point"
-                                - $ref: "#/components/schemas/Polygon"
+                                - $ref: '#/components/schemas/Point'
+                                - $ref: '#/components/schemas/Polygon'
                             properties:
-                              type: "object"
+                              type: 'object'
                               properties:
                                 placetype:
-                                  type: "string"
+                                  type: 'string'
                                 sub_placetype:
-                                  type: "string"
+                                  type: 'string'
         400:
           '$ref': '#/components/responses/BadRequest'
         401:
@@ -423,21 +423,21 @@ paths:
                 type: object
                 properties:
                   type:
-                    type: "string"
+                    type: 'string'
                     enum:
-                      - "Feature"
+                      - 'Feature'
                   geocoding:
-                    type: "object"
+                    type: 'object'
                     properties:
                       query:
-                        type: "object"
+                        type: 'object'
                         properties:
                           lat:
                             type: number
                           lon:
                             type: number
                       response:
-                        type: "object"
+                        type: 'object'
                         properties:
                           max_score:
                             type: number
@@ -446,11 +446,11 @@ paths:
                           match_latency_ms:
                             type: number
                   bbox:
-                    $ref: "#/components/schemas/BoundingBox"
+                    $ref: '#/components/schemas/BoundingBox'
                   geometry:
                     oneOf:
-                      - $ref: "#/components/schemas/Point"
-                      - $ref: "#/components/schemas/Polygon"
+                      - $ref: '#/components/schemas/Point'
+                      - $ref: '#/components/schemas/Polygon'
                   properties:
                     type: object
                     properties:
@@ -598,20 +598,20 @@ components:
       type: 'object'
       properties:
         type:
-          type: "string"
+          type: 'string'
           enum:
-            - "Feature"
+            - 'Feature'
         geocoding:
-          type: "object"
+          type: 'object'
           properties:
             query:
-              type: "object"
+              type: 'object'
               properties:
                 tile:
                   type: string
-                  example: "18SUJ2339007393"
+                  example: '18SUJ2339007393'
             response:
-              type: "object"
+              type: 'object'
               properties:
                 max_score:
                   type: number
@@ -621,11 +621,11 @@ components:
                   type: number
 
         bbox:
-          $ref: "#/components/schemas/BoundingBox"
+          $ref: '#/components/schemas/BoundingBox'
         geometry:
           oneOf:
-            - $ref: "#/components/schemas/Point"
-            - $ref: "#/components/schemas/Polygon"
+            - $ref: '#/components/schemas/Point'
+            - $ref: '#/components/schemas/Polygon'
         properties:
           type: object
           properties:
@@ -633,98 +633,98 @@ components:
               type: number
     tilesSchema:
       allOf:
-        - $ref: "#/components/schemas/genericGeocodingResponse"
-        - type: "object"
-          description: "GeoJson feature collection representing a tile (Polygon)"
+        - $ref: '#/components/schemas/genericGeocodingResponse'
+        - type: 'object'
+          description: 'GeoJson feature collection representing a tile (Polygon)'
           required:
-            - "type"
-            - "features"
+            - 'type'
+            - 'features'
           properties:
             type:
-              type: "string"
+              type: 'string'
               enum:
-                - "FeatureCollection"
+                - 'FeatureCollection'
             features:
-              type: "array"
+              type: 'array'
               items:
-                $ref: "#/components/schemas/tileSchema"
+                $ref: '#/components/schemas/tileSchema'
     itemsSchema:
       allOf:
-        - $ref: "#/components/schemas/genericGeocodingResponse"
-        - type: "object"
-          description: "GeoJson feature collection representing an item"
+        - $ref: '#/components/schemas/genericGeocodingResponse'
+        - type: 'object'
+          description: 'GeoJson feature collection representing an item'
           required:
-            - "type"
-            - "features"
+            - 'type'
+            - 'features'
           properties:
             type:
-              type: "string"
+              type: 'string'
               enum:
-                - "FeatureCollection"
+                - 'FeatureCollection'
             features:
-              type: "array"
+              type: 'array'
               items:
-                type: "object"
+                type: 'object'
                 properties:
                   geometry:
                     oneOf:
-                      - $ref: "#/components/schemas/Point"
-                      - $ref: "#/components/schemas/Polygon"
+                      - $ref: '#/components/schemas/Point'
+                      - $ref: '#/components/schemas/Polygon'
                   properties:
-                    type: "object"
+                    type: 'object'
                     required:
-                      - "TYPE"
-                      - "object_command_name"
-                      - "entity_heb"
-                      - "sub_tile_id"
+                      - 'TYPE'
+                      - 'object_command_name'
+                      - 'entity_heb'
+                      - 'sub_tile_id'
                     properties:
                       TYPE:
-                        type: "string"
+                        type: 'string'
                       object_command_name:
-                        type: "string"
+                        type: 'string'
                       entity_heb:
-                        type: "string"
+                        type: 'string'
                       tile_name:
-                        type: "string"
+                        type: 'string'
                       sub_tile_id:
-                        type: "string"
+                        type: 'string'
     routesSchema:
       allOf:
-        - $ref: "#/components/schemas/genericGeocodingResponse"
-        - type: "object"
-          description: "GeoJson feature collection representing a route (MultiLineString, LineString)"
+        - $ref: '#/components/schemas/genericGeocodingResponse'
+        - type: 'object'
+          description: 'GeoJson feature collection representing a route (MultiLineString, LineString)'
           required:
-            - "type"
-            - "features"
+            - 'type'
+            - 'features'
           properties:
             type:
-              type: "string"
+              type: 'string'
               enum:
-                - "FeatureCollection"
+                - 'FeatureCollection'
             features:
-              type: "array"
+              type: 'array'
               items:
-                type: "object"
+                type: 'object'
                 properties:
                   geometry:
                     oneOf:
-                      - $ref: "#/components/schemas/LineString"
-                      - $ref: "#/components/schemas/MultiLineString"
+                      - $ref: '#/components/schemas/LineString'
+                      - $ref: '#/components/schemas/MultiLineString'
                   properties:
-                    type: "object"
+                    type: 'object'
                     required:
-                      - "TYPE"
-                      - "object_command_name"
-                      - "entity_heb"
+                      - 'TYPE'
+                      - 'object_command_name'
+                      - 'entity_heb'
                     properties:
                       TYPE:
-                        type: "string"
+                        type: 'string'
                       object_command_name:
-                        type: "string"
+                        type: 'string'
                       entity_heb:
-                        type: "string"
+                        type: 'string'
                       SECTION:
-                        type: "string"
+                        type: 'string'
     genericGeocodingResponse: # we need discriminator for Control and Location
       type: 'object'
       description: 'GeoJson feature collection representing an item'


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Further  information:
The OpenAPI.yaml was malformed. Created `geo_context_mode` in `schemas` and refer it correctly both in `GenericGeocodingResponse` and in `geo_context_mode` under `parameters`.
Also pushed missing configuration caused Github Action tests to fail. 
