### PR TITLE
Feat:add get control table route

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -469,7 +469,59 @@ paths:
       security:
         - x-api-key: []
           x-user-id: []
+  /config/control/table:
+    get:
+      operationId: configGetControlTable
+      tags:
+        - Control
+      summary: 'Get Control Grid table'
+      responses:
+        200:
+          description: 'OK'
+          content:
+            application/json:
+              schema:
+                type: object
+                description: 'An object with dynamic keys following the pattern `${latLon.min_x},${latLon.min_y},${latLon.zone}`. Each key represents a coordinate and zone identifier.'
+                additionalProperties:
+                  type: object
+                  properties:
+                    tile_name:
+                      type: string
+                      example: 'BRN'
+                    zone:
+                      type: string
+                      example: '33'
+                    min_x:
+                      type: string
+                      example: '360000'
+                    min_y:
+                      type: string
+                      example: 5820000
+                    ext_min_x:
+                      type: number
+                      example: 360000
+                    ext_min_y:
+                      type: number
+                      example: 5820000
+                    ext_max_x:
+                      type: number
+                      example: 370000
+                    ext_max_y:
+                      type: number
+                      example: 5830000
 
+        400:
+          '$ref': '#/components/responses/BadRequest'
+        401:
+          '$ref': '#/components/responses/Unauthorized'
+        403:
+          '$ref': '#/components/responses/Forbidden'
+        500:
+          '$ref': '#/components/responses/InternalError'
+      security:
+        - x-api-key: []
+          x-user-id: []
 components:
   responses:
     BadRequest:

--- a/src/config/controllers/configController.ts
+++ b/src/config/controllers/configController.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { Logger } from '@map-colonies/js-logger';
+import { BoundCounter, Meter } from '@opentelemetry/api-metrics';
+import { RequestHandler } from 'express';
+import httpStatus from 'http-status-codes';
+import { injectable, inject } from 'tsyringe';
+import { SERVICES } from '../../common/constants';
+import { ConfigManager } from '../models/configManager';
+import { LatLonDAL } from '../../latLon/DAL/latLonDAL';
+
+type GetTilesHandler = RequestHandler<
+  undefined,
+  | ReturnType<LatLonDAL['getLatLonTable']>
+  | {
+      type: string;
+      message: string;
+    },
+  undefined,
+  undefined
+>;
+
+@injectable()
+export class ConfigController {
+  private readonly createdResourceCounter: BoundCounter;
+
+  public constructor(
+    @inject(SERVICES.LOGGER) private readonly logger: Logger,
+    @inject(ConfigManager) private readonly manager: ConfigManager,
+    @inject(SERVICES.METER) private readonly meter: Meter
+  ) {
+    this.createdResourceCounter = meter.createCounter('config_created_resource');
+  }
+
+  public getControlTable: GetTilesHandler = (_, res, next) => {
+    try {
+      const response = this.manager.getControlTable();
+      return res.status(httpStatus.OK).json(response);
+    } catch (error: unknown) {
+      this.logger.error({ msg: 'ConfigController.getControlTable error while trying to return control table', error });
+      next(error);
+    }
+  };
+}

--- a/src/config/controllers/configController.ts
+++ b/src/config/controllers/configController.ts
@@ -6,11 +6,12 @@ import httpStatus from 'http-status-codes';
 import { injectable, inject } from 'tsyringe';
 import { SERVICES } from '../../common/constants';
 import { ConfigManager } from '../models/configManager';
-import { LatLonDAL } from '../../latLon/DAL/latLonDAL';
+import { ConvertCamelToSnakeCase } from '../../common/utils';
+import { LatLon } from '../../latLon/models/latLon';
 
 type GetTilesHandler = RequestHandler<
   undefined,
-  | ReturnType<LatLonDAL['getLatLonTable']>
+  | Record<string, ConvertCamelToSnakeCase<LatLon>>
   | {
       type: string;
       message: string;
@@ -31,11 +32,12 @@ export class ConfigController {
     this.createdResourceCounter = meter.createCounter('config_created_resource');
   }
 
-  public getControlTable: GetTilesHandler = (_, res, next) => {
+  public getControlTable: GetTilesHandler = async (_, res, next) => {
     try {
-      const response = this.manager.getControlTable();
+      const response = await this.manager.getControlTable();
       return res.status(httpStatus.OK).json(response);
-    } catch (error: unknown) {
+    } catch (error: unknown) /* istanbul ignore next */ {
+      // Ignore next in code coverage as we don't expect an error to be thrown but it might happen.
       this.logger.error({ msg: 'ConfigController.getControlTable error while trying to return control table', error });
       next(error);
     }

--- a/src/config/models/configManager.ts
+++ b/src/config/models/configManager.ts
@@ -6,7 +6,8 @@ import { LatLonDAL, latLonDalSymbol } from '../../latLon/DAL/latLonDAL';
 export class ConfigManager {
   public constructor(@inject(latLonDalSymbol) private readonly latLonDAL: LatLonDAL) {}
 
-  public getControlTable(): ReturnType<LatLonDAL['getLatLonTable']> {
-    return this.latLonDAL.getLatLonTable();
+  public async getControlTable(): ReturnType<LatLonDAL['getLatLonTable']> {
+    const response = await this.latLonDAL.getLatLonTable();
+    return response;
   }
 }

--- a/src/config/models/configManager.ts
+++ b/src/config/models/configManager.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { inject, injectable } from 'tsyringe';
+import { LatLonDAL, latLonDalSymbol } from '../../latLon/DAL/latLonDAL';
+
+@injectable()
+export class ConfigManager {
+  public constructor(@inject(latLonDalSymbol) private readonly latLonDAL: LatLonDAL) {}
+
+  public getControlTable(): ReturnType<LatLonDAL['getLatLonTable']> {
+    return this.latLonDAL.getLatLonTable();
+  }
+}

--- a/src/config/routes/configRouter.ts
+++ b/src/config/routes/configRouter.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { FactoryFunction } from 'tsyringe';
+import { ConfigController } from '../controllers/configController';
+
+const configRouterFactory: FactoryFunction<Router> = (dependencyContainer) => {
+  const router = Router();
+  const controller = dependencyContainer.resolve(ConfigController);
+
+  router.get('/control/table', controller.getControlTable);
+
+  return router;
+};
+
+export const CONFIG_ROUTER_SYMBOL = Symbol('configRouterFactory');
+
+export { configRouterFactory };

--- a/src/containerConfig.ts
+++ b/src/containerConfig.ts
@@ -28,6 +28,7 @@ import { s3ClientFactory } from './common/s3';
 import { S3_REPOSITORY_SYMBOL, s3RepositoryFactory } from './common/s3/s3Repository';
 import { healthCheckFactory } from './common/utils';
 import { MGRS_ROUTER_SYMBOL, mgrsRouterFactory } from './mgrs/routes/mgrsRouter';
+import { CONFIG_ROUTER_SYMBOL, configRouterFactory } from './config/routes/configRouter';
 
 export interface RegisterOptions {
   override?: InjectionObject<unknown>[];
@@ -164,6 +165,7 @@ export const registerExternalValues = async (options?: RegisterOptions): Promise
           }
         },
       },
+      { token: CONFIG_ROUTER_SYMBOL, provider: { useFactory: configRouterFactory } },
     ];
     const container = await registerDependencies(dependencies, options?.override, options?.useChild);
     return container;

--- a/src/latLon/DAL/latLonDAL.ts
+++ b/src/latLon/DAL/latLonDAL.ts
@@ -91,7 +91,8 @@ export class LatLonDAL {
     return this.latLonTable[`${x},${y},${zone}`];
   }
 
-  public getLatLonTable(): Record<string, LatLon> {
+  public async getLatLonTable(): Promise<Record<string, LatLon>> {
+    await this.dataLoad?.promise;
     return this.latLonTable;
   }
 

--- a/src/serverBuilder.ts
+++ b/src/serverBuilder.ts
@@ -15,9 +15,9 @@ import { ITEM_ROUTER_SYMBOL } from './control/item/routes/itemRouter';
 import { ROUTE_ROUTER_SYMBOL } from './control/route/routes/routeRouter';
 import { LAT_LON_ROUTER_SYMBOL } from './latLon/routes/latLonRouter';
 import { GEOTEXT_SEARCH_ROUTER_SYMBOL } from './location/routes/locationRouter';
-import { cronLoadTileLatLonDataSymbol } from './latLon/DAL/latLonDAL';
 import { FeedbackApiMiddlewareManager } from './common/middlewares/feedbackApi.middleware';
 import { MGRS_ROUTER_SYMBOL } from './mgrs/routes/mgrsRouter';
+import { CONFIG_ROUTER_SYMBOL } from './config/routes/configRouter';
 
 @injectable()
 export class ServerBuilder {
@@ -31,7 +31,7 @@ export class ServerBuilder {
     @inject(ROUTE_ROUTER_SYMBOL) private readonly routeRouter: Router,
     @inject(LAT_LON_ROUTER_SYMBOL) private readonly latLonRouter: Router,
     @inject(GEOTEXT_SEARCH_ROUTER_SYMBOL) private readonly geotextRouter: Router,
-    @inject(cronLoadTileLatLonDataSymbol) private readonly cronLoadTileLatLonData: void,
+    @inject(CONFIG_ROUTER_SYMBOL) private readonly configRouter: Router,
     @inject(FeedbackApiMiddlewareManager) private readonly feedbackApiMiddleware: FeedbackApiMiddlewareManager,
     @inject(MGRS_ROUTER_SYMBOL) private readonly mgrsRouter: Router
   ) {
@@ -68,6 +68,7 @@ export class ServerBuilder {
 
     this.serverInstance.use('/search', router);
     this.serverInstance.use('/lookup', this.latLonRouter);
+    this.serverInstance.use('/config', this.configRouter);
   }
 
   private buildControlRoutes(): Router {

--- a/tests/integration/config/config.spec.ts
+++ b/tests/integration/config/config.spec.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import 'jest-openapi';
+import { DependencyContainer } from 'tsyringe';
+import { Application } from 'express';
+import { CleanupRegistry } from '@map-colonies/cleanup-registry';
+import jsLogger from '@map-colonies/js-logger';
+import { trace } from '@opentelemetry/api';
+import httpStatusCodes from 'http-status-codes';
+import { getApp } from '../../../src/app';
+import { SERVICES } from '../../../src/common/constants';
+import { cronLoadTileLatLonDataSymbol, LatLonDAL, latLonDalSymbol, latLonSignletonFactory } from '../../../src/latLon/DAL/latLonDAL';
+import { LatLon } from '../../../src/latLon/models/latLon';
+import { ConvertCamelToSnakeCase } from '../../../src/common/utils';
+import { ConfigRequestSender } from './helpers/requestSender';
+
+describe('/config/control/table', function () {
+  let requestSender: ConfigRequestSender;
+  let app: { app: Application; container: DependencyContainer };
+
+  beforeEach(async function () {
+    app = await getApp({
+      override: [
+        { token: SERVICES.LOGGER, provider: { useValue: jsLogger({ enabled: false }) } },
+        { token: SERVICES.TRACER, provider: { useValue: trace.getTracer('testTracer') } },
+        { token: cronLoadTileLatLonDataSymbol, provider: { useValue: {} } },
+        { token: SERVICES.ELASTIC_CLIENTS, provider: { useValue: {} } },
+        { token: latLonDalSymbol, provider: { useFactory: latLonSignletonFactory } },
+      ],
+      useChild: true,
+    });
+
+    requestSender = new ConfigRequestSender(app.app);
+  });
+
+  afterAll(async function () {
+    const cleanupRegistry = app.container.resolve<CleanupRegistry>(SERVICES.CLEANUP_REGISTRY);
+    await cleanupRegistry.trigger();
+    app.container.reset();
+
+    jest.clearAllTimers();
+  });
+
+  describe('Happy Path', function () {
+    it('should return 200 status code and Control Grid table', async function () {
+      const response = await requestSender.getControlTable();
+
+      expect(response.status).toBe(httpStatusCodes.OK);
+      expect(response).toSatisfyApiSpec();
+      expect(response.body).toEqual<Record<string, ConvertCamelToSnakeCase<LatLon>>>({
+        '360000,5820000,33': {
+          tile_name: 'BRN',
+          zone: '33',
+          min_x: '360000',
+          min_y: '5820000',
+          ext_min_x: 360000,
+          ext_min_y: 5820000,
+          ext_max_x: 370000,
+          ext_max_y: 5830000,
+        },
+        '480000,5880000,32': {
+          tile_name: 'BMN',
+          zone: '32',
+          min_x: '480000',
+          min_y: '5880000',
+          ext_min_x: 480000,
+          ext_min_y: 5880000,
+          ext_max_x: 490000,
+          ext_max_y: 5890000,
+        },
+      });
+    });
+  });
+});

--- a/tests/integration/config/helpers/requestSender.ts
+++ b/tests/integration/config/helpers/requestSender.ts
@@ -1,0 +1,14 @@
+import * as supertest from 'supertest';
+
+export class ConfigRequestSender {
+  public constructor(private readonly app: Express.Application) {}
+
+  public async getControlTable(): Promise<supertest.Response> {
+    return supertest
+      .agent(this.app)
+      .get('/config/control/table')
+      .set('Content-Type', 'application/json')
+      .set('x-api-key', 'abc123')
+      .set('x-user-id', 'abc123');
+  }
+}

--- a/tests/unit/config/config.spec.ts
+++ b/tests/unit/config/config.spec.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { InternalServerError } from '../../../src/common/errors';
+import { ConfigManager } from '../../../src/config/models/configManager';
+import { LatLonDAL } from '../../../src/latLon/DAL/latLonDAL';
+
+let configManager: ConfigManager;
+describe('#ConfigManager', () => {
+  beforeEach(() => {
+    const latLonDAL = {
+      getLatLonTable: () => ({
+        '360000,5820000,33': {
+          tile_name: 'BRN',
+          zone: '33',
+          min_x: '360000',
+          min_y: '5820000',
+          ext_min_x: 360000,
+          ext_min_y: 5820000,
+          ext_max_x: 370000,
+          ext_max_y: 5830000,
+        },
+        '480000,5880000,32': {
+          tile_name: 'BMN',
+          zone: '32',
+          min_x: '480000',
+          min_y: '5880000',
+          ext_min_x: 480000,
+          ext_min_y: 5880000,
+          ext_max_x: 490000,
+          ext_max_y: 5890000,
+        },
+      }),
+    } as unknown as LatLonDAL;
+    configManager = new ConfigManager(latLonDAL);
+  });
+
+  describe('happy path', () => {
+    it('should return Control Grid Table data', async () => {
+      const result = await configManager.getControlTable();
+      expect(result).toEqual({
+        '360000,5820000,33': {
+          tile_name: 'BRN',
+          zone: '33',
+          min_x: '360000',
+          min_y: '5820000',
+          ext_min_x: 360000,
+          ext_min_y: 5820000,
+          ext_max_x: 370000,
+          ext_max_y: 5830000,
+        },
+        '480000,5880000,32': {
+          tile_name: 'BMN',
+          zone: '32',
+          min_x: '480000',
+          min_y: '5880000',
+          ext_min_x: 480000,
+          ext_min_y: 5880000,
+          ext_max_x: 490000,
+          ext_max_y: 5890000,
+        },
+      });
+    });
+  });
+
+  describe('sad path', () => {
+    it('should return error', async () => {
+      jest.spyOn(configManager, 'getControlTable').mockRejectedValue(new InternalServerError('Error'));
+      await expect(configManager.getControlTable()).rejects.toThrow('Error');
+    });
+  });
+});


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

Related issues: #17
Closes #XXX ...

Further  information:
Added a new route `/config/control/table`. It will serve the table that is being use to convert between `WGS84` to `Control Grid` Tile. 
This route will be used for our Geocoding-SDK Node.JS package in order to replicate the table locally at the client's-end and convert `WGS84` to `Control Grid` Tile. Some users want to query this route for each mouse movement but we don't want them to spam us. So this is our resolution.  
