### PR TITLE
fix(openapi3.yaml): removed required x-user-id

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -59,8 +59,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
-      security:
-        - x-user-id: []
   /search/location/query:
     get:
       operationId: locationGetQuery
@@ -152,8 +150,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
-      security:
-        - x-user-id: []
   /search/location/regions:
     get:
       operationId: locationGetRegions
@@ -179,8 +175,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
-      security:
-        - x-user-id: []
   /search/location/sources:
     get:
       operationId: locationGetSources
@@ -206,8 +200,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
-      security:
-        - x-user-id: []
   /search/control/tiles:
     get:
       operationId: controlGetTilesByQueryParams
@@ -262,8 +254,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
-      security:
-        - x-user-id: []
   /search/control/items:
     get:
       operationId: controlGetItemsByQueryParams
@@ -313,8 +303,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
-      security:
-        - x-user-id: []
   /search/control/routes:
     get:
       operationId: controlGetRoutesByQueryParams
@@ -324,7 +312,7 @@ paths:
       description: >-
         You can query and get control routes.   <br><br> If you define a route
         (full name of it) you can query the control points associated with
-        it.   
+        it.
       parameters:
         - $ref: '#/components/parameters/token'
         - name: command_name
@@ -360,8 +348,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
-      security:
-        - x-user-id: []
   /search/MGRS/tiles:
     get:
       operationId: getMGRSToGeom
@@ -391,8 +377,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
-      security:
-        - x-user-id: []
   /lookup/coordinates:
     get:
       operationId: convertionGetLatLonToMgrs
@@ -478,8 +462,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
-      security:
-        - x-user-id: []
 components:
   responses:
     BadRequest:


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Related issues: none
Closes: none

Further  information:
After talking with one of our costumer, and because Geocoding service is replacing an old service with about the same API (for `/control`), they asked  us to remove the required `x-user-id`. We did so.  
