### PR TITLE
Refactor: tests change from tomatchobject to toequal

### DIFF
--- a/tests/integration/control/item/item.spec.ts
+++ b/tests/integration/control/item/item.spec.ts
@@ -51,7 +51,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1234, ITEM_1235, ITEM_1236], expect)
       );
     });
@@ -63,7 +63,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1234, ITEM_1235, ITEM_1236], expect)
       );
     });
@@ -75,7 +75,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [], expect)
       );
     });
@@ -92,7 +92,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1236, ITEM_1234, ITEM_1235], expect)
       );
     });
@@ -109,7 +109,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1236], expect)
       );
     });
@@ -131,7 +131,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1236, ITEM_1234, ITEM_1235], expect)
       );
     });
@@ -152,7 +152,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1236], expect)
       );
     });
@@ -173,7 +173,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1236, ITEM_1234, ITEM_1235], expect)
       );
     });
@@ -194,7 +194,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1236], expect)
       );
     });
@@ -209,7 +209,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1234], expect)
       );
     });
@@ -224,7 +224,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [], expect)
       );
     });
@@ -240,7 +240,7 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ITEM_1234, ITEM_1235], expect)
       );
     });
@@ -251,7 +251,7 @@ describe('/search/control/items', function () {
       const response = await requestSender.getItems({} as unknown as GetItemsQueryParams);
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: "request/query must have required property 'command_name'",
       });
     });
@@ -260,7 +260,7 @@ describe('/search/control/items', function () {
       const response = await requestSender.getItems({ command_name: '', limit: 5, disable_fuzziness: false });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: "Empty value found for query parameter 'command_name'",
       });
     });
@@ -269,14 +269,14 @@ describe('/search/control/items', function () {
       let response = await requestSender.getItems({ command_name: '1234', tile: 'invalid', limit: 5, disable_fuzziness: false });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: 'request/query/tile must NOT have more than 3 characters',
       });
 
       response = await requestSender.getItems({ command_name: '1234', tile: 'i', limit: 5, disable_fuzziness: false });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: 'request/query/tile must NOT have fewer than 3 characters',
       });
     });
@@ -289,7 +289,7 @@ describe('/search/control/items', function () {
         const message = sub_tile ? 'request/query/sub_tile must match pattern "^[1-9][0-9]*$"' : "Empty value found for query parameter 'sub_tile'";
 
         expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-        expect(response.body).toMatchObject({
+        expect(response.body).toEqual({
           message,
         });
       }
@@ -315,7 +315,7 @@ describe('/search/control/items', function () {
       const response = await requestSender.getItems({ command_name: '1234', limit: 5, disable_fuzziness: false, ...requestParams });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: '/control/utils/geoContextQuery: geo_context and geo_context_mode must be both defined or both undefined',
       });
     });
@@ -340,7 +340,7 @@ describe('/search/control/items', function () {
       const response = await requestSender.getItems({ command_name: '1234', limit: 5, disable_fuzziness: false, ...requestParams });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: '/control/utils/geoContextQuery: geo_context and geo_context_mode must be both defined or both undefined',
       });
     });
@@ -364,7 +364,7 @@ describe('/search/control/items', function () {
           : 'request/query/disable_fuzziness must be boolean';
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message,
       });
     });
@@ -390,7 +390,7 @@ describe('/search/control/items', function () {
           : 'request/query/limit must be <= 15';
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message,
       });
     });
@@ -434,7 +434,7 @@ describe('/search/control/items', function () {
           });
 
           expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-          expect(response.body).toMatchObject({
+          expect(response.body).toEqual({
             message:
               'geo_context validation: geo_context must contain one of the following: {"bbox": [number,number,number,number] | [number,number,number,number,number,number]}, {"lat": number, "lon": number, "radius": number}, or {"x": number, "y": number, "zone": number, "radius": number}',
           });

--- a/tests/integration/control/route/route.spec.ts
+++ b/tests/integration/control/route/route.spec.ts
@@ -56,7 +56,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ROUTE_VIA_CAMILLUCCIA_A, ROUTE_VIA_CAMILLUCCIA_B], expect)
       );
     });
@@ -73,7 +73,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ROUTE_VIA_CAMILLUCCIA_B, ROUTE_VIA_CAMILLUCCIA_A], expect)
       );
     });
@@ -90,7 +90,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ROUTE_VIA_CAMILLUCCIA_B], expect)
       );
     });
@@ -111,7 +111,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ROUTE_VIA_CAMILLUCCIA_B, ROUTE_VIA_CAMILLUCCIA_A], expect)
       );
     });
@@ -132,7 +132,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ROUTE_VIA_CAMILLUCCIA_B], expect)
       );
     });
@@ -153,7 +153,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ROUTE_VIA_CAMILLUCCIA_B, ROUTE_VIA_CAMILLUCCIA_A], expect)
       );
     });
@@ -174,7 +174,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ROUTE_VIA_CAMILLUCCIA_B], expect)
       );
     });
@@ -189,7 +189,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [ROUTE_VIA_CAMILLUCCIA_B], expect)
       );
     });
@@ -204,7 +204,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [], expect)
       );
     });
@@ -222,7 +222,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [CONTROL_POINT_OLIMPIADE_112, CONTROL_POINT_OLIMPIADE_111], expect)
       );
     });
@@ -240,7 +240,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [CONTROL_POINT_OLIMPIADE_112], expect)
       );
     });
@@ -262,7 +262,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [CONTROL_POINT_OLIMPIADE_112, CONTROL_POINT_OLIMPIADE_111], expect)
       );
     });
@@ -284,7 +284,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [CONTROL_POINT_OLIMPIADE_112], expect)
       );
     });
@@ -306,7 +306,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [CONTROL_POINT_OLIMPIADE_112, CONTROL_POINT_OLIMPIADE_111], expect)
       );
     });
@@ -328,7 +328,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [CONTROL_POINT_OLIMPIADE_112], expect)
       );
     });
@@ -344,7 +344,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [CONTROL_POINT_OLIMPIADE_111, CONTROL_POINT_OLIMPIADE_112], expect)
       );
     });
@@ -360,7 +360,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [CONTROL_POINT_OLIMPIADE_111], expect)
       );
     });
@@ -376,7 +376,7 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [], expect)
       );
     });
@@ -387,7 +387,7 @@ describe('/search/control/route', function () {
       const response = await requestSender.getRoutes({} as unknown as GetRoutesQueryParams);
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: "request/query must have required property 'command_name'",
       });
     });
@@ -396,7 +396,7 @@ describe('/search/control/route', function () {
       const response = await requestSender.getRoutes({ command_name: '', limit: 5, disable_fuzziness: false });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: "Empty value found for query parameter 'command_name'",
       });
     });
@@ -411,7 +411,7 @@ describe('/search/control/route', function () {
           : "Empty value found for query parameter 'control_point'";
 
         expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-        expect(response.body).toMatchObject({
+        expect(response.body).toEqual({
           message,
         });
       }
@@ -437,7 +437,7 @@ describe('/search/control/route', function () {
       const response = await requestSender.getRoutes({ command_name: '1234', limit: 5, disable_fuzziness: false, ...requestParams });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: '/control/utils/geoContextQuery: geo_context and geo_context_mode must be both defined or both undefined',
       });
     });
@@ -462,7 +462,7 @@ describe('/search/control/route', function () {
       const response = await requestSender.getRoutes({ command_name: '1234', limit: 5, disable_fuzziness: false, ...requestParams });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: '/control/utils/geoContextQuery: geo_context and geo_context_mode must be both defined or both undefined',
       });
     });
@@ -486,7 +486,7 @@ describe('/search/control/route', function () {
           : 'request/query/disable_fuzziness must be boolean';
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message,
       });
     });
@@ -512,7 +512,7 @@ describe('/search/control/route', function () {
           : 'request/query/limit must be <= 15';
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message,
       });
     });
@@ -556,7 +556,7 @@ describe('/search/control/route', function () {
           });
 
           expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-          expect(response.body).toMatchObject({
+          expect(response.body).toEqual({
             message:
               'geo_context validation: geo_context must contain one of the following: {"bbox": [number,number,number,number] | [number,number,number,number,number,number]}, {"lat": number, "lon": number, "radius": number}, or {"x": number, "y": number, "zone": number, "radius": number}',
           });

--- a/tests/integration/control/tile/tile.spec.ts
+++ b/tests/integration/control/tile/tile.spec.ts
@@ -52,7 +52,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIT_TILE, RIC_TILE], expect)
       );
     });
@@ -69,7 +69,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIC_TILE, RIT_TILE], expect)
       );
     });
@@ -86,7 +86,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIC_TILE], expect)
       );
     });
@@ -107,7 +107,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIC_TILE, RIT_TILE], expect)
       );
     });
@@ -128,7 +128,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIC_TILE], expect)
       );
     });
@@ -149,7 +149,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIC_TILE, RIT_TILE], expect)
       );
     });
@@ -170,7 +170,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIC_TILE], expect)
       );
     });
@@ -185,7 +185,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIC_TILE], expect)
       );
     });
@@ -200,7 +200,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [], expect)
       );
     });
@@ -216,7 +216,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [SUB_TILE_66, SUB_TILE_65], expect)
       );
     });
@@ -232,7 +232,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [], expect)
       );
     });
@@ -254,7 +254,7 @@ describe('/search/control/tiles', function () {
 
       // expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [SUB_TILE_66], expect)
       );
     });
@@ -276,7 +276,7 @@ describe('/search/control/tiles', function () {
 
       // expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [SUB_TILE_66], expect)
       );
     });
@@ -293,7 +293,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [SUB_TILE_66], expect)
       );
     });
@@ -308,7 +308,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIT_TILE, RIC_TILE], expect)
       );
     });
@@ -329,7 +329,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIC_TILE], expect)
       );
     });
@@ -350,7 +350,7 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
         expectedResponse(requestParams, [RIC_TILE, RIT_TILE], expect)
       );
     });
@@ -361,7 +361,7 @@ describe('/search/control/tiles', function () {
       const response = await requestSender.getTiles({} as unknown as GetTilesQueryParams);
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: "/control/tiles: only one of 'tile' or 'mgrs' query parameter must be defined",
       });
     });
@@ -370,7 +370,7 @@ describe('/search/control/tiles', function () {
       const response = await requestSender.getTiles({ tile: '', limit: 5, disable_fuzziness: false });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: "Empty value found for query parameter 'tile'",
       });
     });
@@ -379,14 +379,14 @@ describe('/search/control/tiles', function () {
       let response = await requestSender.getTiles({ tile: 'invalid', limit: 5, disable_fuzziness: false });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: 'request/query/tile must NOT have more than 3 characters',
       });
 
       response = await requestSender.getTiles({ tile: 'i', limit: 5, disable_fuzziness: false });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: 'request/query/tile must NOT have fewer than 2 characters',
       });
     });
@@ -395,14 +395,14 @@ describe('/search/control/tiles', function () {
       let response = await requestSender.getTiles({ mgrs: '', limit: 5, disable_fuzziness: false });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: "Empty value found for query parameter 'mgrs'",
       });
 
       response = await requestSender.getTiles({ tile: 'i', limit: 5, disable_fuzziness: false });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: 'request/query/tile must NOT have fewer than 2 characters',
       });
     });
@@ -413,7 +413,7 @@ describe('/search/control/tiles', function () {
         const response = await requestSender.getTiles({ mgrs, limit: 5, disable_fuzziness: false });
 
         expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-        expect(response.body).toMatchObject({
+        expect(response.body).toEqual({
           message: `Invalid MGRS: ${mgrs}`,
         });
       }
@@ -431,7 +431,7 @@ describe('/search/control/tiles', function () {
         });
 
         expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-        expect(response.body).toMatchObject({
+        expect(response.body).toEqual({
           message:
             'geo_context validation: geo_context must contain one of the following: {"bbox": [number,number,number,number] | [number,number,number,number,number,number]}, {"lat": number, "lon": number, "radius": number}, or {"x": number, "y": number, "zone": number, "radius": number}',
         });
@@ -446,7 +446,7 @@ describe('/search/control/tiles', function () {
         const message = sub_tile ? 'request/query/sub_tile must match pattern "^[1-9][0-9]*$"' : "Empty value found for query parameter 'sub_tile'";
 
         expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-        expect(response.body).toMatchObject({
+        expect(response.body).toEqual({
           message,
         });
       }
@@ -472,7 +472,7 @@ describe('/search/control/tiles', function () {
       const response = await requestSender.getTiles({ tile: 'RIT', limit: 5, disable_fuzziness: false, ...requestParams });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: '/control/utils/geoContextQuery: geo_context and geo_context_mode must be both defined or both undefined',
       });
     });
@@ -496,7 +496,7 @@ describe('/search/control/tiles', function () {
           : 'request/query/disable_fuzziness must be boolean';
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message,
       });
     });
@@ -522,7 +522,7 @@ describe('/search/control/tiles', function () {
           : 'request/query/limit must be <= 15';
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message,
       });
     });
@@ -566,7 +566,7 @@ describe('/search/control/tiles', function () {
           });
 
           expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-          expect(response.body).toMatchObject({
+          expect(response.body).toEqual({
             message:
               'geo_context validation: geo_context must contain one of the following: {"bbox": [number,number,number,number] | [number,number,number,number,number,number]}, {"lat": number, "lon": number, "radius": number}, or {"x": number, "y": number, "zone": number, "radius": number}',
           });

--- a/tests/integration/location/location.spec.ts
+++ b/tests/integration/location/location.spec.ts
@@ -73,7 +73,7 @@ describe('/search/location', function () {
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
 
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Feature>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Feature>>(
         expectedResponse(
           {
             ...requestParams,
@@ -125,7 +125,7 @@ describe('/search/location', function () {
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
 
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Feature>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Feature>>(
         expectedResponse(
           requestParams,
           {
@@ -174,7 +174,7 @@ describe('/search/location', function () {
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
 
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Feature>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Feature>>(
         expectedResponse(
           {
             ...requestParams,
@@ -263,7 +263,7 @@ describe('/search/location', function () {
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
 
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Feature>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Feature>>(
         expectedResponse(
           {
             ...requestParams,
@@ -317,7 +317,7 @@ describe('/search/location', function () {
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
 
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Feature>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Feature>>(
         expectedResponse(
           {
             ...requestParams,
@@ -367,7 +367,7 @@ describe('/search/location', function () {
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
 
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Feature>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Feature>>(
         expectedResponse(
           requestParams,
           {
@@ -398,7 +398,7 @@ describe('/search/location', function () {
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
 
-      expect(response.body).toMatchObject<GenericGeocodingResponse<Feature>>(
+      expect(response.body).toEqual<GenericGeocodingResponse<Feature>>(
         expectedResponse(
           requestParams,
           {
@@ -446,7 +446,7 @@ describe('/search/location', function () {
       const response = await requestSender.getQuery(badRequestParams);
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: '/location/geotextQuery: geo_context and geo_context_mode must be both defined or both undefined',
       });
       tokenTypesUrlScope.done();
@@ -563,7 +563,7 @@ describe('/search/location', function () {
           });
 
           expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-          expect(response.body).toMatchObject({
+          expect(response.body).toEqual({
             message:
               'geo_context validation: geo_context must contain one of the following: {"bbox": [number,number,number,number] | [number,number,number,number,number,number]}, {"lat": number, "lon": number, "radius": number}, or {"x": number, "y": number, "zone": number, "radius": number}',
           });

--- a/tests/integration/location/utils.ts
+++ b/tests/integration/location/utils.ts
@@ -24,6 +24,7 @@ const expectedGeocodingElasticResponseMetrics = (
   nlp_anlyser_latency_ms: expect.any(Number) as number,
   place_type_latency_ms: expect.any(Number) as number,
   hierarchies_latency_ms: expect.any(Number) as number,
+  name: expect.any(String) as string,
   ...responseParams,
 });
 

--- a/tests/integration/mgrs/mgrs.spec.ts
+++ b/tests/integration/mgrs/mgrs.spec.ts
@@ -95,7 +95,7 @@ describe('/search/MGRS', function () {
     it('should return 400 status code when MGRS is invalid', async function () {
       const response = await requestSender.getTile({ tile: 'ABC{}' });
 
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: 'Invalid MGRS tile. MGRSPoint bad conversion from ABC{}',
       });
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
@@ -105,7 +105,7 @@ describe('/search/MGRS', function () {
       const response = await requestSender.getTile();
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: "request/query must have required property 'tile'",
       });
     });
@@ -114,7 +114,7 @@ describe('/search/MGRS', function () {
       const response = await requestSender.getTile({ tile: '{ABC}' });
 
       expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      expect(response.body).toMatchObject({
+      expect(response.body).toEqual({
         message: 'Invalid MGRS tile. MGRSPoint zone letter A not handled: {ABC}',
       });
     });

--- a/tests/mockObjects/tiles.ts
+++ b/tests/mockObjects/tiles.ts
@@ -18,6 +18,7 @@ export const RIT_TILE: Tile = {
     type: 'Polygon',
   },
   properties: {
+    LAYER_NAME: 'CONTROL.TILES',
     TILE_NAME: 'RIT',
     TYPE: 'TILE',
   },
@@ -26,6 +27,7 @@ export const RIT_TILE: Tile = {
 export const RIC_TILE: Tile = {
   type: 'Feature',
   properties: {
+    LAYER_NAME: 'CONTROL.TILES',
     TILE_NAME: 'RIC',
     TYPE: 'TILE',
   },
@@ -46,6 +48,7 @@ export const RIC_TILE: Tile = {
 export const SUB_TILE_66: Tile = {
   type: 'Feature',
   properties: {
+    LAYER_NAME: 'CONTROL.SUB_TILES',
     SUB_TILE_ID: '66',
     TILE_NAME: 'RIT',
     TYPE: 'SUB_TILE',
@@ -67,6 +70,7 @@ export const SUB_TILE_66: Tile = {
 export const SUB_TILE_65: Tile = {
   type: 'Feature',
   properties: {
+    LAYER_NAME: 'CONTROL.SUB_TILES',
     SUB_TILE_ID: '65',
     TILE_NAME: 'RIT',
     TYPE: 'SUB_TILE',


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further  information:
In the tests I've changed from `toMatchObject` to `toEqual` to be more stricted in tests' responses