### PR TITLE
docs: added missing bbox to genericGeocodingResponse

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -799,6 +799,8 @@ components:
                   type: integer
                   minimum: 0
                   maximum: 5000
+        bbox:
+          $ref: '#/components/schemas/BoundingBox'
         features:
           type: array
           items:
@@ -999,7 +1001,7 @@ components:
       items:
         type: number
       minLength: 4
-      maxLength: 4
+      maxLength: 6
     WGS84Circle:
       type: object
       properties:


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✔                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further  information:
added missing bbox in `genericGeocodingResponse` in our openapi
