### PR TITLE
Feat/item sub type

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -84,7 +84,9 @@
       "SUB_TILE": "Sub Tile",
       "ROUTE": "Route",
       "ITEM": "Item",
-      "CONTROL_POINT": "Control Point"
+      "CONTROL_POINT": "Control Point",
+      "CONTROL_CROSS": "Control Cross",
+      "CONTROL_INFRASTRUCTURE": "Control Infrastructure"
     },
     "nameTranslationsKeys": ["en", "fr"],
     "mainLanguageRegex": "[a-zA-Z]"

--- a/devScripts/controlElasticsearchData.json
+++ b/devScripts/controlElasticsearchData.json
@@ -381,6 +381,7 @@
         "F_CODE": 8754111,
         "F_ATT": 951111,
         "ENTITY_HEB": "control point",
+        "SUB_TYPE": "CONTROL_POINT",
         "LAYER_NAME": "CONTROL_GIL_GDB.CTR_CONTROL_POINT_CROSS_N",
         "TYPE": "ITEM",
         "regions": [
@@ -406,9 +407,10 @@
         "TIED_TO": "olimpiade",
         "F_CODE": 875411,
         "F_ATT": 95111,
-        "ENTITY_HEB": "control point",
+        "ENTITY_HEB": "control cross",
         "LAYER_NAME": "CONTROL_GIL_GDB.CTR_CONTROL_POINT_CROSS_N",
-        "TYPE": "ITEM"
+        "TYPE": "ITEM",
+        "SUB_TYPE": "CONTROL_CROSS"
       }
     }
   },

--- a/src/control/constants.ts
+++ b/src/control/constants.ts
@@ -20,4 +20,5 @@ export const CONTROL_FIELDS = [
   'properties.TIED_TO',
   'properties.LAYER_NAME',
   'properties.regions',
+  'properties.SUB_TYPE',
 ];

--- a/src/control/item/models/item.ts
+++ b/src/control/item/models/item.ts
@@ -8,5 +8,6 @@ export interface Item extends Feature {
     OBJECT_COMMAND_NAME: string;
     LAYER_NAME: string;
     TIED_TO?: string;
+    SUB_TYPE?: 'CONTROL_CROSS' | 'CONTROL_INFRASTRUCTURE' | 'CONTROL_POINT';
   };
 }

--- a/src/control/utils.ts
+++ b/src/control/utils.ts
@@ -18,14 +18,18 @@ const generateDisplayName = <T extends Tile | Item | Route>(
   displayNamePrefixes: IApplication['controlObjectDisplayNamePrefixes']
 ): (string | undefined)[] => {
   const sourceType =
-    source.properties.TYPE === 'ITEM' && (source as Item).properties.TIED_TO !== undefined ? 'CONTROL_POINT' : source.properties.TYPE;
+    source.properties.TYPE === 'ITEM' && (source as Item).properties.SUB_TYPE !== undefined
+      ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        (source as Item).properties.SUB_TYPE!
+      : source.properties.TYPE;
 
   const name: (string | undefined)[] = [];
   sourceType === 'TILE' && name.unshift((source as Tile).properties.TILE_NAME);
   sourceType === 'SUB_TILE' && name.unshift((source as Tile).properties.SUB_TILE_ID);
   sourceType === 'ITEM' && name.unshift((source as Item).properties.OBJECT_COMMAND_NAME);
   sourceType === 'ROUTE' && name.unshift((source as Route).properties.OBJECT_COMMAND_NAME);
-  sourceType === 'CONTROL_POINT' && name.unshift((source as Item).properties.OBJECT_COMMAND_NAME);
+  ['CONTROL_CROSS', 'CONTROL_INFRASTRUCTURE', 'CONTROL_POINT'].find((val) => val === sourceType) !== undefined &&
+    name.unshift((source as Item).properties.OBJECT_COMMAND_NAME);
 
   name.unshift(displayNamePrefixes[sourceType]);
 
@@ -34,7 +38,7 @@ const generateDisplayName = <T extends Tile | Item | Route>(
     name.unshift(displayNamePrefixes['TILE']);
   }
 
-  if (sourceType === 'CONTROL_POINT') {
+  if (['CONTROL_CROSS', 'CONTROL_INFRASTRUCTURE', 'CONTROL_POINT'].find((val) => val === sourceType) !== undefined) {
     name.unshift((source as Item).properties.TIED_TO);
     name.unshift(displayNamePrefixes['ROUTE']);
   }

--- a/tests/mockObjects/routes.ts
+++ b/tests/mockObjects/routes.ts
@@ -64,6 +64,7 @@ export const CONTROL_POINT_OLIMPIADE_111: Route = {
     type: 'Point',
   },
   properties: {
+    SUB_TYPE: 'CONTROL_POINT',
     OBJECT_COMMAND_NAME: '111',
     ENTITY_HEB: 'control point',
     TIED_TO: 'olimpiade',
@@ -86,10 +87,11 @@ export const CONTROL_POINT_OLIMPIADE_112: Route = {
   },
   properties: {
     OBJECT_COMMAND_NAME: '112',
-    ENTITY_HEB: 'control point',
+    ENTITY_HEB: 'control cross',
     TIED_TO: 'olimpiade',
     TYPE: 'ITEM' as never,
     LAYER_NAME: 'CONTROL_GIL_GDB.CTR_CONTROL_POINT_CROSS_N',
     regions: [],
+    SUB_TYPE: 'CONTROL_CROSS',
   },
 };

--- a/tests/unit/control/route/route.spec.ts
+++ b/tests/unit/control/route/route.spec.ts
@@ -15,7 +15,12 @@ let routeManager: RouteManager;
 describe('#RouteManager', () => {
   const getRoutes = jest.fn();
   const getControlPointInRoute = jest.fn();
-  const controlObjectDisplayNamePrefixes = { ROUTE: 'Route', CONTROL_POINT: 'Control Point' };
+  const controlObjectDisplayNamePrefixes = {
+    ROUTE: 'Route',
+    CONTROL_POINT: 'Control Point',
+    CONTROL_CROSS: 'Control Cross',
+    CONTROL_INFRASTRUCTURE: 'Control Infrastructure',
+  };
   beforeEach(() => {
     jest.resetAllMocks();
 


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Related issues: #47 
Closes #47 

Further  information:
We've added SUB_TYPE to items because now on a route there are more control 'features'. 
possible values are now:
1. CONTROL_CROSS
2. CONTROL_INFRASTRUCTURE
3. CONTROL_POINT

