### PR TITLE
Fix/bbox array of nulls if no results are found

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -639,6 +639,7 @@ components:
           oneOf:
             - $ref: '#/components/schemas/Point'
             - $ref: '#/components/schemas/Polygon'
+            - $ref: '#/components/schemas/MultiPolygon'
         properties:
           type: object
           properties:
@@ -1002,6 +1003,7 @@ components:
         type: number
       minLength: 4
       maxLength: 6
+      nullable: true
     WGS84Circle:
       type: object
       properties:

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -24,8 +24,9 @@ export interface GeoContext {
   zone?: number;
 }
 
-export interface FeatureCollection<T extends Feature> extends GeoJSONFeatureCollection {
+export interface FeatureCollection<T extends Feature> extends Omit<GeoJSONFeatureCollection, 'bbox'> {
   features: T[];
+  bbox?: BBox | null;
 }
 
 export interface WGS84Coordinate {
@@ -93,7 +94,6 @@ export interface GenericGeocodingResponse<T extends Feature, G = any> extends Fe
       /* eslint-enable @typescript-eslint/naming-convention */
     } & { [key: string]: unknown };
   };
-  bbox: BBox;
   features: (T & {
     properties: RemoveUnderscore<Pick<estypes.SearchHit<T>, '_score'>> &
       GeoJsonProperties & {

--- a/src/control/utils.ts
+++ b/src/control/utils.ts
@@ -99,7 +99,7 @@ export const formatResponse = <T extends Tile | Item | Route>(
       }) as GenericGeocodingResponse<T>['features']),
     ],
   };
-  return { ...geoJSONFeatureCollection, bbox: bbox(geoJSONFeatureCollection) };
+  return { ...geoJSONFeatureCollection, bbox: geoJSONFeatureCollection.features.length > 0 ? bbox(geoJSONFeatureCollection) : null };
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/location/utils.ts
+++ b/src/location/utils.ts
@@ -117,7 +117,7 @@ export const convertResult = (
   };
   return {
     ...geoJSONFeatureCollection,
-    bbox: bbox(geoJSONFeatureCollection),
+    bbox: geoJSONFeatureCollection.features.length > 0 ? bbox(geoJSONFeatureCollection) : null,
   };
 };
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/tests/integration/control/item/item.spec.ts
+++ b/tests/integration/control/item/item.spec.ts
@@ -75,9 +75,10 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
-        expectedResponse(requestParams, [], expect)
-      );
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>({
+        ...expectedResponse(requestParams, [], expect),
+        bbox: null,
+      });
     });
 
     it('should return 200 status code and tiles biased by geo_context (bbox)', async function () {
@@ -224,9 +225,10 @@ describe('/search/control/items', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>(
-        expectedResponse(requestParams, [], expect)
-      );
+      expect(response.body).toEqual<GenericGeocodingResponse<Item, Omit<GetItemsQueryParams, keyof CommonRequestParameters>>>({
+        ...expectedResponse(requestParams, [], expect),
+        bbox: null,
+      });
     });
 
     it('should return 200 status code and items in sub_tile', async function () {

--- a/tests/integration/control/route/route.spec.ts
+++ b/tests/integration/control/route/route.spec.ts
@@ -204,9 +204,10 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
-        expectedResponse(requestParams, [], expect)
-      );
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>({
+        ...expectedResponse(requestParams, [], expect),
+        bbox: null,
+      });
     });
 
     it('should return 200 status code and control points biased by geo_context (bbox)', async function () {
@@ -376,9 +377,10 @@ describe('/search/control/route', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>(
-        expectedResponse(requestParams, [], expect)
-      );
+      expect(response.body).toEqual<GenericGeocodingResponse<Route, Omit<GetRoutesQueryParams, keyof CommonRequestParameters>>>({
+        ...expectedResponse(requestParams, [], expect),
+        bbox: null,
+      });
     });
   });
   describe('Bad Path', function () {

--- a/tests/integration/control/tile/tile.spec.ts
+++ b/tests/integration/control/tile/tile.spec.ts
@@ -200,9 +200,10 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
-        expectedResponse(requestParams, [], expect)
-      );
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>({
+        ...expectedResponse(requestParams, [], expect),
+        bbox: null,
+      });
     });
 
     it('should return 200 status code and sub tiles', async function () {
@@ -232,9 +233,10 @@ describe('/search/control/tiles', function () {
 
       expect(response.status).toBe(httpStatusCodes.OK);
       // expect(response).toSatisfyApiSpec();
-      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>(
-        expectedResponse(requestParams, [], expect)
-      );
+      expect(response.body).toEqual<GenericGeocodingResponse<Tile, Omit<GetTilesQueryParams, keyof CommonRequestParameters>>>({
+        ...expectedResponse(requestParams, [], expect),
+        bbox: null,
+      });
     });
 
     it('should return 200 status code and sub_tile "66" filtered by geo_context (UTM)', async function () {

--- a/tests/integration/location/location.spec.ts
+++ b/tests/integration/location/location.spec.ts
@@ -448,6 +448,26 @@ describe('/search/location', function () {
 
       tokenTypesUrlScope.done();
     });
+
+    it('should return 200 status code and no results', async function () {
+      const requestParams: GetGeotextSearchParams = { query: 'shfdsfdsfddfsd', limit: 5, disable_fuzziness: true };
+      const tokenTypesUrlScope = nock(config.get<IApplication>('application').services.tokenTypesUrl)
+        .post('', { tokens: requestParams.query.split(' ') })
+        .reply(httpStatusCodes.OK, [
+          {
+            tokens: [requestParams.query],
+            prediction: ['essence'],
+          },
+        ]);
+
+      const response = await requestSender.getQuery(requestParams);
+
+      expect(response.status).toBe(httpStatusCodes.OK);
+      expect((response.body as GenericGeocodingResponse<Feature>).features).toHaveLength(0);
+      expect((response.body as GenericGeocodingResponse<Feature>).bbox).toBeNull();
+
+      tokenTypesUrlScope.done();
+    });
   });
 
   describe('Bad Path', function () {


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further  information:
Bbox as a response were added in version 0.2.0. Because of an error in our pre-design, we didn't made bbox nullable. It is now. 
It is "Breaking change" but no user uses it as it is still in integration environment and was never added to production.   
