### PR TITLE
fix: added 'disable' prefix to boolean-parameter-prefixes

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -23,7 +23,7 @@ lint:
   rules:
     boolean-parameter-prefixes:
       severity: error
-      prefixes: ['should', 'is', 'has']
+      prefixes: ['should', 'is', 'has', 'disable']
     no-unused-components:
       severity: error
     no-empty-servers: off


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔/✖                                                                        |
| Chore            | ✖                                                                       |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further  information:
Added 'disable' as allowed prefix to boolean variables in OpenAPI linter