### PR TITLE
fix: use NotFound response, remove subTileSchema

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -58,6 +58,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalError'
   /search/location/query:
@@ -601,23 +603,6 @@ components:
           type: string
         status:
           type: number
-    subTileSchema:
-      type: object
-      description: An object represnting a sub tile
-      required:
-        - tileName
-        - subTileNumber
-      properties:
-        tileName:
-          type: string
-        subTileNumber:
-          type: array
-          items:
-            type: number
-            minimum: 0
-            maximum: 100
-          minItems: 3
-          maxItems: 3
     tileSchema:
       type: object
       properties:


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔/✖                                                                        |
| New feature     | ✔/✖                                                                        |
| Breaking change | ✔/✖                                                                        |
| Deprecations    | ✔/✖                                                                        |
| Documentation   | ✔/✖                                                                        |
| Tests added     | ✔/✖                                                                        |
| Chore            | ✔/✖                                                                       |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further  information:
use 404 in /query as optional response, remove subTileSchema as it is not used
