### PR TITLE
Feat/ignore roads unless explicitly

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -128,6 +128,10 @@
     },
     "mainLanguageRegex": "MAIN_LANGUAGE_REGEX",
     "site": "SITE",
-    "geotextCitiesLayer": "GEOTEXT_CITIES_LAYER"
+    "geotextCitiesLayer": "GEOTEXT_CITIES_LAYER",
+    "roadPlaceTypes": {
+      "__name": "GEOTEXT_ROAD_PLACETYPES",
+      "__format": "json"
+    }
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -28,7 +28,7 @@
   "db": {
     "elastic": {
       "control": {
-        "node": "http://elasticsearch:9200",
+        "node": "http://control_elastic:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -39,7 +39,7 @@
         }
       },
       "geotext": {
-        "node": "http://elasticsearch:9200",
+        "node": "http://geotext_elastic:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -56,7 +56,7 @@
       }
     },
     "s3": {
-      "endpoint": "http://minio:9000",
+      "endpoint": "http://s3:9000",
       "credentials": {
         "accessKeyId": "accessKeyId",
         "secretAccessKey": "secretAccessKey"

--- a/config/default.json
+++ b/config/default.json
@@ -28,7 +28,7 @@
   "db": {
     "elastic": {
       "control": {
-        "node": "http://localhost:9200",
+        "node": "http://elasticsearch:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -39,7 +39,7 @@
         }
       },
       "geotext": {
-        "node": "http://localhost:9200",
+        "node": "http://elasticsearch:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -56,10 +56,10 @@
       }
     },
     "s3": {
-      "endpoint": "http://localhost:9000",
+      "endpoint": "http://minio:9000",
       "credentials": {
-        "accessKeyId": "minio",
-        "secretAccessKey": "minio123"
+        "accessKeyId": "accessKeyId",
+        "secretAccessKey": "secretAccessKey"
       },
       "forcePathStyle": true,
       "region": "local",
@@ -87,7 +87,7 @@
   "application": {
     "site": "local",
     "services": {
-      "tokenTypesUrl": "http://localhost:5001/NLP_ANALYSES"
+      "tokenTypesUrl": "http://NLP_ANALYSES"
     },
     "cronLoadTileLatLonDataPattern": "0 * * * *",
     "elasticQueryBoosts": {

--- a/config/default.json
+++ b/config/default.json
@@ -28,7 +28,7 @@
   "db": {
     "elastic": {
       "control": {
-        "node": "http://control_elastic:9200",
+        "node": "http://localhost:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -39,7 +39,7 @@
         }
       },
       "geotext": {
-        "node": "http://geotext_elastic:9200",
+        "node": "http://localhost:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -56,10 +56,10 @@
       }
     },
     "s3": {
-      "endpoint": "http://s3:9000",
+      "endpoint": "http://localhost:9000",
       "credentials": {
-        "accessKeyId": "accessKeyId",
-        "secretAccessKey": "secretAccessKey"
+        "accessKeyId": "minio",
+        "secretAccessKey": "minio123"
       },
       "forcePathStyle": true,
       "region": "local",
@@ -87,7 +87,7 @@
   "application": {
     "site": "local",
     "services": {
-      "tokenTypesUrl": "http://NLP_ANALYSES"
+      "tokenTypesUrl": "http://localhost:5001/NLP_ANALYSES"
     },
     "cronLoadTileLatLonDataPattern": "0 * * * *",
     "elasticQueryBoosts": {
@@ -99,6 +99,25 @@
       "geotextCitiesLayer": 1.1
     },
     "geotextCitiesLayer": "google_cities",
+    "roadPlaceTypes": ["road"],
+    "sources": {
+      "osm": "OSM",
+      "google": "GOOGLE"
+    },
+    "regions": {
+      "USA": ["New York", "Los Angeles"],
+      "FRANCE": ["Paris"]
+    },
+    "controlObjectDisplayNamePrefixes": {
+      "TILE": "Tile",
+      "SUB_TILE": "Sub Tile",
+      "ROUTE": "Route",
+      "ITEM": "Item",
+      "CONTROL_POINT": "Control Point",
+      "CONTROL_CROSS": "Control Cross",
+      "CONTROL_INFRASTRUCTURE": "Control Infrastructure"
+    },
+    "nameTranslationsKeys": ["en", "fr"],
     "mainLanguageRegex": "[a-zA-Z]"
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -2,7 +2,7 @@
   "db": {
     "elastic": {
       "control": {
-        "node": "http://elasticsearch:9200",
+        "node": "http://localhost:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -13,7 +13,7 @@
         }
       },
       "geotext": {
-        "node": "http://elasticsearch:9200",
+        "node": "http://localhost:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -30,7 +30,7 @@
       }
     },
     "s3": {
-      "endpoint": "http://minio:9000",
+      "endpoint": "http://localhost:9000",
       "credentials": {
         "accessKeyId": "minio",
         "secretAccessKey": "minio123"
@@ -73,6 +73,7 @@
       "geotextCitiesLayer": 1.1
     },
     "geotextCitiesLayer": "google_cities",
+    "roadPlaceTypes": ["road"],
     "sources": {
       "osm": "OSM",
       "google": "GOOGLE"

--- a/config/test.json
+++ b/config/test.json
@@ -2,7 +2,7 @@
   "db": {
     "elastic": {
       "control": {
-        "node": "http://localhost:9200",
+        "node": "http://elasticsearch:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -13,7 +13,7 @@
         }
       },
       "geotext": {
-        "node": "http://localhost:9200",
+        "node": "http://elasticsearch:9200",
         "auth": {
           "username": "elastic",
           "password": "changeme"
@@ -30,7 +30,7 @@
       }
     },
     "s3": {
-      "endpoint": "http://localhost:9000",
+      "endpoint": "http://minio:9000",
       "credentials": {
         "accessKeyId": "minio",
         "secretAccessKey": "minio123"

--- a/devScripts/geotextElasticsearchData.json
+++ b/devScripts/geotextElasticsearchData.json
@@ -223,6 +223,46 @@
     }
   },
   {
+    "_id": "b3d2ad4a-7444-41b7-916e-80ab8f3122c8",
+    "_index": "geotext",
+    "_source": {
+      "source": "osm",
+      "layer_name": "osm_roads",
+      "ingestion_timestamp": "2024-07-17 00:00:00",
+      "timestamp": "11/12/2023 00:00:00",
+      "source_id": ["{670b800c-605c-4528-8eb7-147b7ed80f38}"],
+      "sensitivity": "non-sensitive",
+      "placetype": "road",
+      "sub_placetype": "road",
+      "wkt": "LINESTRING (-118.2247760920702 34.02992273700272, -118.24319913817602 34.023502987817736, -118.27208982411435 34.03755640111636, -118.3011898628498 34.03738291637846, -118.33908271904448 34.03512758249674, -118.36525181862649 34.03391314710892, -118.3788597504093 34.03668897387864, -118.39518926854844 34.03026973663613)",
+      "geo_json": {
+        "coordinates": [
+          [-118.2247760920702, 34.02992273700272],
+          [-118.24319913817602, 34.023502987817736],
+          [-118.27208982411435, 34.03755640111636],
+          [-118.3011898628498, 34.03738291637846],
+          [-118.33908271904448, 34.03512758249674],
+          [-118.36525181862649, 34.03391314710892],
+          [-118.3788597504093, 34.03668897387864],
+          [-118.39518926854844, 34.03026973663613]
+        ],
+        "type": "LineString"
+      },
+      "centroid": {
+        "type": "Point",
+        "coordinates": [-118.3011898628498, 34.03738291637846]
+      },
+      "geometry_type": "Polygon",
+      "geometry_hash": "da9ca04844973d49e2b3378c090dbe23",
+      "region": ["USA"],
+      "sub_region": ["Los Angeles"],
+      "name": "Los Angeles",
+      "text": ["Los Angeles"],
+      "translated_text": [""],
+      "text_language": "en"
+    }
+  },
+  {
     "_id": "1bb11f54-939e-457b-bf68-a3920ccf629c",
     "_index": "geotext",
     "_source": {
@@ -729,7 +769,7 @@
     }
   },
   {
-    "_id": "a3f38afc-1ce6-443c-a302-a0103c2bcb7d",
+    "_id": "74598231-939a-49c9-9228-807997213a16",
     "_index": "hierarchies",
     "_source": {
       "geo_json": {
@@ -772,7 +812,16 @@
     }
   },
   {
-    "_id": "6941ab8e-7503-4f8a-94f2-4750b2698db9",
+    "_id": "ee4b5add-cf6d-4ee6-89ae-2bfc3efc0c2c",
+    "_index": "placetypes",
+    "_source": {
+      "placetype": "road",
+      "sub_placetype": "road",
+      "sub_placetype_keyword": "road"
+    }
+  },
+  {
+    "_id": "efc2cb11-363e-48fe-9310-b1f5adb018ea",
     "_index": "placetypes",
     "_source": {
       "placetype": "education",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -59,6 +59,7 @@ export interface IApplication {
     [key: string]: string;
   };
   geotextCitiesLayer: string;
+  roadPlaceTypes: string[];
 }
 
 export enum GeoContextMode {

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -58,8 +58,8 @@ export interface IApplication {
   controlObjectDisplayNamePrefixes: {
     [key: string]: string;
   };
-  geotextCitiesLayer: string;
-  roadPlaceTypes: string[];
+  geotextCitiesLayer?: string;
+  roadPlaceTypes?: string[];
 }
 
 export enum GeoContextMode {

--- a/src/location/DAL/locationRepository.ts
+++ b/src/location/DAL/locationRepository.ts
@@ -99,11 +99,11 @@ const createGeotextRepository = (client: ElasticClient, logger: Logger) => {
       params: TextSearchParams,
       textLanguage: string,
       elasticQueryBoosts: IApplication['elasticQueryBoosts'],
-      geotextCitiesLayer?: IApplication['geotextCitiesLayer']
+      geotextLayerName?: { geotextCitiesLayer?: IApplication['geotextCitiesLayer']; roadPlaceTypes?: IApplication['roadPlaceTypes'] }
     ): Promise<estypes.SearchResponse<TextSearchHit>> {
       const response = await queryElastic<TextSearchHit>(client, {
         index,
-        ...geotextQuery(params, textLanguage, elasticQueryBoosts, geotextCitiesLayer),
+        ...geotextQuery(params, textLanguage, elasticQueryBoosts, geotextLayerName),
       });
       return response;
     },

--- a/src/location/models/locationManager.ts
+++ b/src/location/models/locationManager.ts
@@ -62,7 +62,7 @@ export class GeotextSearchManager {
       searchParams,
       this.config.get<ElasticDbClientsConfig>(elasticConfigPath).geotext.properties.textTermLanguage,
       this.appConfig.elasticQueryBoosts,
-      this.appConfig.geotextCitiesLayer
+      { geotextCitiesLayer: this.appConfig.geotextCitiesLayer, roadPlaceTypes: this.appConfig.roadPlaceTypes }
     );
 
     return convertResult(searchParams, esResult, {

--- a/tests/mockObjects/locations.ts
+++ b/tests/mockObjects/locations.ts
@@ -175,6 +175,30 @@ export const LA_AIRPORT: MockLocationQueryFeature = {
   },
 };
 
+export const LA_ROAD: MockLocationQueryFeature = {
+  type: 'Feature',
+  geometry: {
+    coordinates: [
+      [-118.2247760920702, 34.02992273700272],
+      [-118.24319913817602, 34.023502987817736],
+      [-118.27208982411435, 34.03755640111636],
+      [-118.3011898628498, 34.03738291637846],
+      [-118.33908271904448, 34.03512758249674],
+      [-118.36525181862649, 34.03391314710892],
+      [-118.3788597504093, 34.03668897387864],
+      [-118.39518926854844, 34.03026973663613],
+    ],
+    type: 'LineString',
+  },
+  properties: {
+    matches: [{ layer: 'osm_roads', source: 'OSM', source_id: ['670b800c-605c-4528-8eb7-147b7ed80f38'] }],
+    names: { en: ['Los Angeles'], fr: [''], default: ['Los Angeles'], display: 'Los Angeles, road, road, USA, Los Angeles, OSM' },
+    placetype: 'road',
+    sub_placetype: 'road',
+    regions: [{ region: 'USA', sub_region_names: ['Los Angeles'] }],
+  },
+};
+
 export const OSM_LA_PORT: MockLocationQueryFeature = {
   type: 'Feature',
   geometry: {


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

Further  information:
We've decided that until we'll have a "smart" logic to prioritize layers over others, we will filter roads data unless the figured placetype is "road". 
In order to be dynamic with the filtered data, we added GEOTEXT_ROAD_PLACETYPES env (in order to support other types of roads placetype like 'highway')

