### PR TITLE
fix: removed mocked config from default config

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -98,16 +98,10 @@
       "viewbox": 1.1,
       "geotextCitiesLayer": 1.1
     },
-    "geotextCitiesLayer": "google_cities",
-    "roadPlaceTypes": ["road"],
-    "sources": {
-      "osm": "OSM",
-      "google": "GOOGLE"
-    },
-    "regions": {
-      "USA": ["New York", "Los Angeles"],
-      "FRANCE": ["Paris"]
-    },
+    "geotextCitiesLayer": "cities_index",
+    "roadPlaceTypes": [],
+    "sources": {},
+    "regions": {},
     "controlObjectDisplayNamePrefixes": {
       "TILE": "Tile",
       "SUB_TILE": "Sub Tile",
@@ -117,7 +111,7 @@
       "CONTROL_CROSS": "Control Cross",
       "CONTROL_INFRASTRUCTURE": "Control Infrastructure"
     },
-    "nameTranslationsKeys": ["en", "fr"],
+    "nameTranslationsKeys": [],
     "mainLanguageRegex": "[a-zA-Z]"
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -82,15 +82,6 @@
       "USA": ["New York", "Los Angeles"],
       "FRANCE": ["Paris"]
     },
-    "controlObjectDisplayNamePrefixes": {
-      "TILE": "Tile",
-      "SUB_TILE": "Sub Tile",
-      "ROUTE": "Route",
-      "ITEM": "Item",
-      "CONTROL_POINT": "Control Point",
-      "CONTROL_CROSS": "Control Cross",
-      "CONTROL_INFRASTRUCTURE": "Control Infrastructure"
-    },
     "nameTranslationsKeys": ["en", "fr"],
     "mainLanguageRegex": "[a-zA-Z]"
   }


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further  information:
Removed mock config from `config/default.json`. 
Config from type `"__format": "json"` being injected by `envs` are being deep marged instead of overridden 