### PR TITLE
fix: await redis connection before cleanup

### DIFF
--- a/src/common/redis/index.ts
+++ b/src/common/redis/index.ts
@@ -14,9 +14,9 @@ const createConnectionOptions = (redisConfig: RedisConfig): Partial<RedisClientO
       clientOptions.socket = {
         ...clientOptions.socket,
         tls: true,
-        key: readFileSync(tls.key),
-        cert: readFileSync(tls.cert),
-        ca: readFileSync(tls.ca),
+        key: tls.key ? readFileSync(tls.key) : undefined,
+        cert: tls.cert ? readFileSync(tls.cert) : undefined,
+        ca: tls.ca ? readFileSync(tls.ca) : undefined,
       };
     } catch (error) {
       throw new Error(`Failed to load Redis SSL certificates. Ensure the files exist and are accessible. Details: ${(error as Error).message}`);

--- a/src/containerConfig.ts
+++ b/src/containerConfig.ts
@@ -193,16 +193,16 @@ export const registerExternalValues = async (options?: RegisterOptions): Promise
           const logger = deps.resolve<Logger>(SERVICES.LOGGER);
           try {
             const redis = deps.resolve<RedisClient>(SERVICES.REDIS);
-            cleanupRegistry.register({
-              func: async (): Promise<void> => {
-                await redis.quit();
-                return Promise.resolve();
-              },
-              id: SERVICES.REDIS,
-            });
+
             await redis.connect();
+
+            cleanupRegistry.register({
+              id: SERVICES.REDIS,
+              func: redis.quit.bind(redis),
+            });
           } catch (error) {
             logger.error({ msg: 'Connection to redis failed', error });
+            throw error;
           }
         },
       },


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✔  |
| New feature     | ✖ |
| Breaking change | ✖  |
| Deprecations    | ✖  |
| Documentation   | ✖  |
| Tests added     | ✖  |
| Chore           | ✖  |

Related issues: #XXX , #XXX ...
Closes #XXX ...

Further information:
Redis symbol registration had a problem where it first registered cleanup and then connected, and so I fixed its' order.